### PR TITLE
Enable the project to be runnable again

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "awesome-typescript-loader": "3.2.3",
     "typescript": "2.5.3",
     "webpack": "2.2.0",
-    "webpack-dev-server": "2.2.0"
+    "webpack-dev-server": "2.2.0",
+    "@types/request": "^0.0.45"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "allowJs": true,
     "outDir": "dist",


### PR DESCRIPTION
## Overview of Changes
- Use `es6` instead of `es5` to prevent bluebird for raising unrecoverable exceptions about missing ES6 types.
- Explicitly add `@types/request` in `package.json` to ensure a compatible version is fetched to be able to run the dev server used for the project. 